### PR TITLE
Changed injected msAVFlags order.

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -138,7 +138,7 @@ def verify_kerberos_password(user, password, domain, kdc_host=None, request_pac=
 
     try:
         tgt = sendReceive(encoder.encode(asReq), domain, kdc_host)
-    except Exception, e:
+    except Exception as e:
         if str(e).find('KDC_ERR_PREAUTH_FAILED') >= 0:
             return False
         raise
@@ -238,7 +238,8 @@ def mod_computeResponseNTLMv2(flags, serverChallenge, clientChallenge, serverNam
     if vuln == "CVE-2019-1040":
         av_pairs[NTLMSSP_AV_FLAGS] = [b'\x02' + b'\x00' * 3]
     if vuln == "CVE-2019-1166":
-        av_pairs[NTLMSSP_AV_FLAGS] = [b'\x02' + b'\x00' * 3, b'\x00' * 4]
+        #av_pairs[NTLMSSP_AV_FLAGS] = [b'\x02' + b'\x00' * 3, b'\x00' * 4]
+        av_pairs[NTLMSSP_AV_FLAGS] = [ b'\x00' * 4, b'\x02' + b'\x00' * 3]
     serverName = av_pairs.getData()
 
     temp = responseServerVersion + hiResponseServerVersion + b'\x00' * 6 + aTime + clientChallenge + b'\x00' * 4 + \


### PR DESCRIPTION
Hi, I read your article about CVE-2019-1166 a.k.a "drop the mic 2" here https://www.preempt.com/blog/active-directory-ntlm-attacks/.  I started to play a bit with your tool scan.py and i saw that it puts first an msAVFlag with value 0x2 on top of another one with value 0x0 in the TargetInfoFields structure.
Looking at your article from what i understood the two flags should be swapped, in the structure TargetInfo, in order to verify the vulnerability. The one value 0x0 should be on top of the other one with value 0x2, that is the modification i made.
This is what i get with the original order (output taken from pycharm):
![image](https://user-images.githubusercontent.com/74059030/98467538-2a389000-21d6-11eb-8037-1db7970e79a4.png)

![image](https://user-images.githubusercontent.com/74059030/98467028-6d453400-21d3-11eb-8aa2-5988f6851015.png)

This is what i get with the two flag attribute swapped:
![image](https://user-images.githubusercontent.com/74059030/98467574-6bc93b00-21d6-11eb-9758-9aca0cf3d69d.png)

![image](https://user-images.githubusercontent.com/74059030/98466908-c2347a80-21d2-11eb-83f7-5eeda741071a.png)

I'm just a student so i could have misunderstood some things, let me know if the modification i made was correct.